### PR TITLE
Restore prettyPiece helper

### DIFF
--- a/app.js
+++ b/app.js
@@ -241,6 +241,12 @@ function toBoardPosition(state){
   return map;
 }
 
+function prettyPiece(p){
+  const names = {K:'King',Q:'Queen',R:'Rook',B:'Bishop',N:'Knight',P:'Pawn'};
+  const side = p.color === 'w' ? 'White' : 'Black';
+  return `${side} ${names[p.kind]}`;
+}
+
 function endGame(msg){ S.over=true; setStatus(msg); }
 function log(msg){ S.log.unshift(msg); if (S.log.length>40) S.log.pop(); document.getElementById('log').innerHTML = S.log.map(l=>`• ${l}`).join('<br>'); }
 function setStatus(t){ document.getElementById('status').textContent = t; }


### PR DESCRIPTION
## Summary
- restore prettyPiece helper to convert piece IDs into human-readable names for logging

## Testing
- `node --check app.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a71fbfe6708324b1d743f5b36d137f