### PR TITLE
Add main setup and info page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
 # Fable Tactics
 
+## Main Page
+
+Open `main.html` in a browser to learn the rules and how to start a match.
+
 ## Dashboard
 
-
+The dashboard (`dashboard.html`) lets you inspect piece stats and launch a game.
 
 ## Testing
 

--- a/main.html
+++ b/main.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Fable Tactics</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <h1>Fable Tactics</h1>
+  <p>Welcome to Fable Tactics, a stat-based take on chess. Use this page to get set up and learn the basics before diving into a match.</p>
+  <h2>Setup</h2>
+  <ol>
+    <li>Visit the <a href="dashboard.html">Dashboard</a> to choose a piece type and view its stats.</li>
+    <li>Press <strong>Start Game</strong> on the dashboard to launch the board.</li>
+    <li>Play the game on the <a href="game.html">Game Board</a>.</li>
+  </ol>
+  <h2>How it Works</h2>
+  <p>Each piece has hit points (HP), attack (ATK), defense (DEF), and sometimes a movement limit (MOVE). Damage is calculated as <code>max(1, ATK − DEF)</code> and you win by defeating the opposing king.</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add new `main.html` landing page with setup guidance and game overview
- Document main page and dashboard usage in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b6347dd20883248d7206bc8c653a77