### PR TITLE
Fix front-end setup so game runs

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,4 +1,10 @@
+/* Main game script for Fable Tactics. */
 
+const GE = window.gameEngine;
+let S = GE.initialSetup();
+let board;
+let legal = [];
+let origin = null;
 
 function pieceTheme(pieceCode) {
   const c = pieceCode[0] === 'w' ? 'w' : 'b';
@@ -6,63 +12,27 @@ function pieceTheme(pieceCode) {
   return `https://cdnjs.cloudflare.com/ajax/libs/chessboard.js/1.0.0/img/chesspieces/wikipedia/${c}${t}.png`;
 }
 
-function onDragStart(source, piece, pos, orientation) {
-  if (S.over) return false;
-  const color = piece[0];
-  if (color !== S.turn) return false;
-
-  if (!pid) return false;
-  S.selected = pid;
-  highlightLegal(pid);
+function log(msg){
+  S.log.push(msg);
+  const el = document.getElementById('log');
+  const div = document.createElement('div');
+  div.textContent = msg;
+  el.appendChild(div);
+  el.scrollTop = el.scrollHeight;
 }
 
-function onDrop(source, target) {
-  clearHighlights();
-  const pid = S.selected;
-  S.selected = null;
-  if (!pid) return 'snapback';
-
-
-  const mv = legal.find(m => m.from === source && m.to === target);
-  if (!mv) return 'snapback';
-
-  const before = cloneState(S);
-  const attacker = S.pieces[pid];
-  const defId = S.pos[target];
-
-  if (!defId) {
-
-  } else {
-    const defender = S.pieces[defId];
-    const dmg = Math.max(1, attacker.atk - defender.def);
-    defender.hp -= dmg;
-    if (defender.hp <= 0) {
-      delete S.pos[target];
-      delete S.loc[defId];
-
-      log(`${prettyPiece(attacker)} attacks ${prettyPiece(defender)} at ${target} for ${dmg} — defeated`);
-      if (defender.kind === 'K') endGame(`${attacker.color === 'w' ? 'White' : 'Black'} wins (king defeated)`);
-    } else {
-      log(`${prettyPiece(attacker)} attacks ${prettyPiece(defender)} at ${target} for ${dmg} — ${defender.hp} HP left`);
-
-    }
-  }
-
-  if (!S.over) S.turn = (S.turn === 'w') ? 'b' : 'w';
-
-  board.position(toBoardPosition(S));
-  renderHUD();
-  drawOverlays();
+function renderHUD(){
+  const turnEl = document.getElementById('turn');
+  turnEl.textContent = S.over ? '' : `Turn: ${S.turn === 'w' ? 'White' : 'Black'}`;
+  if (S.over) document.getElementById('status').textContent = S.status || '';
 }
 
-function onSnapEnd() {
-  board.position(toBoardPosition(S));
+function endGame(msg){
+  S.over = true;
+  S.status = msg;
+  document.getElementById('status').textContent = msg;
 }
 
-
-}
-
-// ---------- Visual Overlays (HP badges & legal highlights) ----------
 function drawOverlays(){
   const squares = document.querySelectorAll('#board .square-55d63');
   squares.forEach(el => {
@@ -75,17 +45,16 @@ function drawOverlays(){
     if (!el) continue;
     const b = document.createElement('div');
     b.className = 'hp-badge';
-
+    b.textContent = p.hp;
     el.appendChild(b);
   }
 }
 
-function highlightLegal(pid){
+function highlightLegal(pid, from, moves){
   clearHighlights();
-
-  const me = document.querySelector(`#board .square-${mySq}`);
+  const me = document.querySelector(`#board .square-${from}`);
   if (me) me.classList.add('legal');
-  for (const m of ls){
+  for (const m of moves){
     const el = document.querySelector(`#board .square-${m.to}`);
     if (!el) continue;
     if (S.pos[m.to] && S.pieces[S.pos[m.to]].color !== S.pieces[pid].color) el.classList.add('enemy');
@@ -93,15 +62,86 @@ function highlightLegal(pid){
   }
   const p = S.pieces[pid];
   document.getElementById('selected').innerHTML =
-    `<div class="stat"><b>${prettyPiece(p)}</b></div>`+
+    `<div class="stat"><b>${GE.prettyPiece(p)}</b></div>`+
     `<div class="stat">HP ${p.hp}</div>`+
     `<div class="stat">ATK ${p.atk}</div>`+
     `<div class="stat">DEF ${p.def}</div>`+
     `${p.move?`<div class="stat">MOVE ${p.move}</div>`:''}`+
-
-    `<div>Square: <b>${mySq}</b></div>`;
+    `<div>Square: <b>${from}</b></div>`;
 }
 
 function clearHighlights(){
   document.querySelectorAll('#board .square-55d63').forEach(el => el.classList.remove('legal','enemy'));
 }
+
+function onDragStart(source, piece){
+  if (S.over) return false;
+  const color = piece[0];
+  if (color !== S.turn) return false;
+  const pid = S.pos[source];
+  if (!pid) return false;
+  S.selected = pid;
+  origin = source;
+  legal = GE.legalMoves(S, pid);
+  highlightLegal(pid, origin, legal);
+}
+
+function onDrop(source, target){
+  clearHighlights();
+  const pid = S.selected;
+  S.selected = null;
+  if (!pid) return 'snapback';
+  const mv = legal.find(m => m.from === source && m.to === target);
+  if (!mv) return 'snapback';
+
+  const before = GE.cloneState(S);
+  const defId = before.pos[target];
+  const result = GE.resolveCombat(S, pid, target);
+  const attacker = S.pieces[pid];
+
+  if (result.type === 'move'){
+    log(`${GE.prettyPiece(attacker)} moves from ${source} to ${target}`);
+  } else if (result.type === 'defeat'){
+    const defender = before.pieces[defId];
+    log(`${GE.prettyPiece(attacker)} attacks ${GE.prettyPiece(defender)} at ${target} for ${result.dmg} — defeated`);
+    if (defender.kind === 'K') endGame(`${attacker.color === 'w' ? 'White' : 'Black'} wins (king defeated)`);
+  } else if (result.type === 'hit'){
+    const defender = S.pieces[defId];
+    log(`${GE.prettyPiece(attacker)} attacks ${GE.prettyPiece(defender)} at ${target} for ${result.dmg} — ${defender.hp} HP left`);
+  }
+
+  if (!S.over) S.turn = (S.turn === 'w') ? 'b' : 'w';
+
+  board.position(GE.toBoardPosition(S));
+  renderHUD();
+  drawOverlays();
+}
+
+function onSnapEnd(){
+  board.position(GE.toBoardPosition(S));
+}
+
+function newGame(){
+  S = GE.initialSetup();
+  document.getElementById('log').innerHTML = '';
+  board.position(GE.toBoardPosition(S));
+  renderHUD();
+  drawOverlays();
+}
+
+document.getElementById('new').addEventListener('click', newGame);
+document.getElementById('flip').addEventListener('click', () => {
+  board.flip();
+});
+
+board = Chessboard('board', {
+  draggable: true,
+  position: GE.toBoardPosition(S),
+  pieceTheme: pieceTheme,
+  onDragStart: onDragStart,
+  onDrop: onDrop,
+  onSnapEnd: onSnapEnd
+});
+
+renderHUD();
+drawOverlays();

--- a/dashboard.html
+++ b/dashboard.html
@@ -8,7 +8,7 @@
 </head>
 <body>
   <h1>Fable Tactics Dashboard</h1>
-  <div id="dashboard" class="panel">
+    <div id="dashboard" class="panel">
     <label for="pieceSelect">Choose a piece type:</label>
     <select id="pieceSelect">
       <option value="K">King</option>
@@ -21,6 +21,7 @@
     <div id="stats" style="margin-top:12px"></div>
     <button id="startBtn" style="margin-top:12px">Start Game</button>
   </div>
-  <script src="dashboard.js"></script>
-</body>
+    <script src="gameEngine.js"></script>
+    <script src="dashboard.js"></script>
+  </body>
 </html>

--- a/dashboard.js
+++ b/dashboard.js
@@ -1,11 +1,6 @@
-const pieceStats = {
-  K:{hp:10, atk:3, def:2},
-  Q:{hp:7, atk:5, def:1, move:7},
-  R:{hp:6, atk:4, def:2, move:7},
-  B:{hp:5, atk:3, def:1, move:7},
-  N:{hp:5, atk:3, def:2},
-  P:{hp:3, atk:2, def:0}
-};
+/* Dashboard for inspecting piece stats and starting a game. */
+
+const { pieceStats } = window.gameEngine;
 
 function updateStats(){
   const type = document.getElementById('pieceSelect').value;
@@ -21,5 +16,7 @@ function updateStats(){
 
 document.getElementById('pieceSelect').addEventListener('change', updateStats);
 document.getElementById('startBtn').addEventListener('click', () => {
+  window.location.href = 'game.html';
+});
 
 updateStats();

--- a/game.html
+++ b/game.html
@@ -38,7 +38,7 @@
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.4/jquery.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/chessboard.js/1.0.0/chessboard-1.0.0.min.js"></script>
-
+  <script src="gameEngine.js"></script>
   <script src="app.js"></script>
 </body>
 </html>

--- a/gameEngine.js
+++ b/gameEngine.js
@@ -167,11 +167,47 @@ function resolveCombat(state, attackerId, targetSq){
   }
 }
 
+function toBoardPosition(state){
+  const map = {};
+  for (const [sq,id] of Object.entries(state.pos)){
+    const p = state.pieces[id];
+    map[sq] = p.color + p.kind;
+  }
+  return map;
+}
+
+function prettyPiece(p){
+  const names = {K:'King',Q:'Queen',R:'Rook',B:'Bishop',N:'Knight',P:'Pawn'};
+  const side = p.color === 'w' ? 'White' : 'Black';
+  return `${side} ${names[p.kind]}`;
+}
+
+function cloneState(s){
+  return typeof structuredClone === 'function' ? structuredClone(s) : JSON.parse(JSON.stringify(s));
+}
+
 module.exports = {
   initialSetup,
   legalMoves,
   movesPawn,
   resolveCombat,
   movePiece,
-  pieceStats
+  pieceStats,
+  toBoardPosition,
+  prettyPiece,
+  cloneState
 };
+
+if (typeof window !== 'undefined') {
+  window.gameEngine = {
+    initialSetup,
+    legalMoves,
+    movesPawn,
+    resolveCombat,
+    movePiece,
+    pieceStats,
+    toBoardPosition,
+    prettyPiece,
+    cloneState
+  };
+}


### PR DESCRIPTION
## Summary
- expose additional helpers from gameEngine for browser use
- wire game and dashboard HTML pages to load engine and start a match
- rebuild app.js and dashboard.js for interactive play with HP overlays and logs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b63a5522808324ba7529fae41df031